### PR TITLE
adds a TypeScript generator to a Rug archive project

### DIFF
--- a/.atomist.yml
+++ b/.atomist.yml
@@ -45,3 +45,19 @@ editor:
     - "editor_name": "MyFirstEditor"
     - "description": "This is my very first editor"
 
+---
+kind: "operation"
+client: "atomist"
+editor:
+  name: "AddTypeScriptGenerator"
+  group: "atomist-rugs"
+  artifact: "rug-editors"
+  version: "0.13.0"
+  origin:
+    repo: "https://github.com/atomist-rugs/rug-editors.git"
+    branch: "8f7b8da48226325ba1e7f83520bc7436f9f0f792"
+    sha: "8f7b8da"
+  parameters:
+    - "generator_name": "MyFirstGenerator"
+    - "description": "My first generator"
+

--- a/.atomist/editors/MyFirstGenerator.ts
+++ b/.atomist/editors/MyFirstGenerator.ts
@@ -1,0 +1,26 @@
+import { PopulateProject } from '@atomist/rug/operations/ProjectGenerator'
+import { Project } from '@atomist/rug/model/Core'
+import { Pattern } from '@atomist/rug/operations/RugOperation'
+import { Generator, Parameter, Tags } from '@atomist/rug/operations/Decorators'
+
+@Generator("MyFirstGenerator", "sample TypeScript generator used by AddMyFirstGenerator")
+@Tags("documentation")
+class MyFirstGenerator implements PopulateProject {
+
+    // this is only necessary to avoid https://github.com/atomist/rug-resolver/issues/17
+    @Parameter({
+        displayName: "Project Name",
+        description: "name of project to be created",
+        pattern: Pattern.project_name,
+        validInput: "a valid GitHub project name consisting of alphanumeric, ., -, and _ characters",
+        minLength: 1,
+        maxLength: 100
+    })
+    project_name: string;
+
+    populate(project: Project) {
+        project.deleteFile(".atomist.yml");
+    }
+}
+
+export const myFirstGenerator = new MyFirstGenerator();

--- a/.atomist/tests/MyFirstGenerator.rt
+++ b/.atomist/tests/MyFirstGenerator.rt
@@ -1,0 +1,12 @@
+scenario MyFirstGenerator should create a new project based on this archive
+
+let project_name = "my-project-name"
+
+given
+  Empty
+
+when
+  MyFirstGenerator
+
+then
+  fileExists "README.md"

--- a/README.md
+++ b/README.md
@@ -34,6 +34,34 @@ $ rug edit atomist-rugs:rug-editors:MyFirstEditor \
 
 Explain what your editor does here.
 
+### MyFirstGenerator
+
+My first generator
+
+#### Prerequisites
+
+This Rug has no prerequisites.
+
+#### Parameters
+
+This Rug takes following parameters.
+
+Name | Required | Default | Description
+-----|----------|---------|------------
+`project_name` | Yes | | Name of project to be created
+
+#### Running
+
+Run this Rug as follows:
+
+```
+$ cd parent/directory
+$ rug generate atomist-rugs:rug-editors:MyFirstGenerator \
+    my-new-project
+```
+
+Explain what your generator does here.
+
 
 ## Support
 


### PR DESCRIPTION
Created by Atomist Editor `AddTypeScriptGenerator`
```
---
kind: "operation"
client: "atomist-bot"
editor:
  name: "AddTypeScriptGenerator"
  group: "atomist-rugs"
  artifact: "rug-editors"
  version: "0.13.0"
  origin:
    repo: "https://github.com/atomist-rugs/rug-editors.git"
    branch: "8f7b8da48226325ba1e7f83520bc7436f9f0f792"
    sha: "8f7b8da"
  parameters:
    - "generator_name": "MyFirstGenerator"
    - "description": "My first generator"

```